### PR TITLE
Correct error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Add the `<CascadingBlazoredModal />` component into your applications *App.razor
 
 ### 4. Add reference to style sheet & javascript reference
 
-Add the following line to the `head` tag of your `_Host.cshtml` (Blazor Server) or `index.html` (Blazor WebAssembly).
+Add the following line to the `head` tag of your `_Layout.cshtml` (Blazor Server) or `index.html` (Blazor WebAssembly).
 
 ```html
 <link href="_content/Blazored.Modal/blazored-modal.css" rel="stylesheet" />


### PR DESCRIPTION
Step 4 referred to adding the .css and .js files to _host.cshtml for Blazor Server, however the correct place for these files to be called is in _Layout.cshtml for Blazor Server running on .net6